### PR TITLE
Let developers access the initiator element in visit/fetch events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     "no-multiple-empty-lines": ["error", { "max": 2 }],
     "no-self-assign": ["error", { "props": false }],
     "no-trailing-spaces": ["error"],
-    "no-unused-vars": ["error", { argsIgnorePattern: "_*" , "ignoreRestSiblings": true}],
+    "no-unused-vars": ["error", { argsIgnorePattern: "_*" }],
     "no-useless-escape": "off",
     "no-var": ["error"],
     "prefer-const": ["error"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     "no-multiple-empty-lines": ["error", { "max": 2 }],
     "no-self-assign": ["error", { "props": false }],
     "no-trailing-spaces": ["error"],
-    "no-unused-vars": ["error", { argsIgnorePattern: "_*" }],
+    "no-unused-vars": ["error", { argsIgnorePattern: "_*" , "ignoreRestSiblings": true}],
     "no-useless-escape": "off",
     "no-var": ["error"],
     "prefer-const": ["error"],

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -12,7 +12,7 @@ export class Navigator {
   proposeVisit(location, options = {}) {
     if (this.delegate.allowsVisitingLocation(location, options)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
-        this.withInitiator(options.initiator, () => {
+        this.withVisitOptions(options, () => {
           this.delegate.visitProposedToLocation(location, options)
         })
       } else {
@@ -24,9 +24,9 @@ export class Navigator {
   startVisit(locatable, restorationIdentifier, options = {}) {
     this.stop()
     this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, {
-      initiator: this.currentInitiator,
       referrer: this.location,
-      ...options
+      ...this.currentVisitOptions,
+      ...options,
     })
     this.currentVisit.start()
   }
@@ -160,9 +160,9 @@ export class Navigator {
 
   // Private
 
-  withInitiator(initiator, callback) {
-    this.currentInitiator = initiator
+  withVisitOptions(options, callback) {
+    this.currentVisitOptions = options
     callback.call(this)
-    delete this.currentInitiator
+    delete this.currentVisitOptions
   }
 }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -168,7 +168,13 @@ export class Navigator {
   }
 
   #sanitizeVisitOptionsForTransfer(options) {
-    const { initiator, referrer, visitCachedSnapshot, ...rest } = options
-    return window.structuredClone(rest)
+    return Object.entries(options).reduce((sanitized, [key, value]) => {
+      try {
+        sanitized[key] = window.structuredClone(value)
+      } catch (_) {
+        // Ignore non-transferable values
+      }
+      return sanitized
+    }, {})
   }
 }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -26,7 +26,7 @@ export class Navigator {
     this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, {
       referrer: this.location,
       ...this.currentVisitOptions,
-      ...options,
+      ...options
     })
     this.currentVisit.start()
   }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -163,6 +163,6 @@ export class Navigator {
   withVisitOptions(options, callback) {
     this.currentVisitOptions = options
     callback.call(this)
-    delete this.currentVisitOptions
+    this.currentVisitOptions = {}
   }
 }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -5,6 +5,8 @@ import { Visit } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export class Navigator {
+  proposedVisitOptions = {}
+
   constructor(delegate) {
     this.delegate = delegate
   }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -10,9 +10,11 @@ export class Navigator {
   }
 
   proposeVisit(location, options = {}) {
-    if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
+    if (this.delegate.allowsVisitingLocation(location, options)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
-        this.delegate.visitProposedToLocation(location, options)
+        this.withInitiator(options.initiator, () => {
+          this.delegate.visitProposedToLocation(location, options)
+        })
       } else {
         window.location.href = location.toString()
       }
@@ -22,6 +24,7 @@ export class Navigator {
   startVisit(locatable, restorationIdentifier, options = {}) {
     this.stop()
     this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, {
+      initiator: this.currentInitiator,
       referrer: this.location,
       ...options
     })
@@ -153,5 +156,13 @@ export class Navigator {
 
   getActionForFormSubmission({ submitter, formElement }) {
     return getVisitAction(submitter, formElement) || "advance"
+  }
+
+  // Private
+
+  withInitiator(initiator, callback) {
+    this.currentInitiator = initiator
+    callback.call(this)
+    delete this.currentInitiator
   }
 }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -12,7 +12,7 @@ export class Navigator {
   proposeVisit(location, options = {}) {
     if (this.delegate.allowsVisitingLocation(location, options)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
-        this.withTransferableVisitOptions(options, (transferableOptions) => {
+        this.#withTransferableVisitOptions(options, (transferableOptions) => {
           this.delegate.visitProposedToLocation(location, transferableOptions)
         })
       } else {
@@ -158,9 +158,7 @@ export class Navigator {
     return getVisitAction(submitter, formElement) || "advance"
   }
 
-  // Private
-
-  withTransferableVisitOptions(options, callback) {
+  #withTransferableVisitOptions(options, callback) {
     this.currentVisitOptions = options
     try {
       callback.call(this, this.#sanitizeVisitOptionsForTransfer(options))
@@ -171,7 +169,7 @@ export class Navigator {
     }
   }
 
-  sanitizeVisitOptionsForTransfer(options) {
+  #sanitizeVisitOptionsForTransfer(options) {
     const { initiator, referrer, visitCachedSnapshot, ...rest } = options
     return rest
   }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -25,7 +25,7 @@ export class Navigator {
     this.stop()
     this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, {
       referrer: this.location,
-      ...this.currentVisitOptions,
+      ...this.proposedVisitOptions,
       ...options
     })
     this.currentVisit.start()
@@ -159,13 +159,13 @@ export class Navigator {
   }
 
   #withTransferableVisitOptions(options, callback) {
-    this.currentVisitOptions = options
+    this.proposedVisitOptions = options
     try {
       callback.call(this, this.#sanitizeVisitOptionsForTransfer(options))
     } catch (error) {
       throw error
     } finally {
-      this.currentVisitOptions = {}
+      this.proposedVisitOptions = {}
     }
   }
 

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -162,8 +162,13 @@ export class Navigator {
 
   withTransferableVisitOptions(options, callback) {
     this.currentVisitOptions = options
-    callback.call(this, this.sanitizeVisitOptionsForTransfer(options))
-    this.currentVisitOptions = {}
+    try {
+      callback.call(this, this.#sanitizeVisitOptionsForTransfer(options))
+    } catch (error) {
+      throw error
+    } finally {
+      this.currentVisitOptions = {}
+    }
   }
 
   sanitizeVisitOptionsForTransfer(options) {

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -171,6 +171,6 @@ export class Navigator {
 
   #sanitizeVisitOptionsForTransfer(options) {
     const { initiator, referrer, visitCachedSnapshot, ...rest } = options
-    return rest
+    return structuredClone(rest)
   }
 }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -162,8 +162,6 @@ export class Navigator {
     this.proposedVisitOptions = options
     try {
       callback.call(this, this.#sanitizeVisitOptionsForTransfer(options))
-    } catch (error) {
-      throw error
     } finally {
       this.proposedVisitOptions = {}
     }
@@ -171,6 +169,6 @@ export class Navigator {
 
   #sanitizeVisitOptionsForTransfer(options) {
     const { initiator, referrer, visitCachedSnapshot, ...rest } = options
-    return structuredClone(rest)
+    return window.structuredClone(rest)
   }
 }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -12,8 +12,8 @@ export class Navigator {
   proposeVisit(location, options = {}) {
     if (this.delegate.allowsVisitingLocation(location, options)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
-        this.withVisitOptions(options, () => {
-          this.delegate.visitProposedToLocation(location, options)
+        this.withTransferableVisitOptions(options, (transferableOptions) => {
+          this.delegate.visitProposedToLocation(location, transferableOptions)
         })
       } else {
         window.location.href = location.toString()
@@ -160,9 +160,14 @@ export class Navigator {
 
   // Private
 
-  withVisitOptions(options, callback) {
+  withTransferableVisitOptions(options, callback) {
     this.currentVisitOptions = options
-    callback.call(this)
+    callback.call(this, this.sanitizeVisitOptionsForTransfer(options))
     this.currentVisitOptions = {}
+  }
+
+  sanitizeVisitOptionsForTransfer(options) {
+    const { initiator, referrer, visitCachedSnapshot, ...rest } = options
+    return rest
   }
 }

--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -85,6 +85,7 @@ export class Navigator {
         const { statusCode, redirected } = fetchResponse
         const action = this.getActionForFormSubmission(formSubmission)
         const visitOptions = {
+          initiator: formSubmission.formElement,
           action,
           shouldCacheSnapshot,
           response: { statusCode, responseHTML, redirected }

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -66,7 +66,7 @@ export class Visit {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
-      initiator,
+      initiator
     } = {
       ...defaultOptions,
       ...options

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -65,7 +65,8 @@ export class Visit {
       willRender,
       updateHistory,
       shouldCacheSnapshot,
-      acceptsStreamResponse
+      acceptsStreamResponse,
+      initiator,
     } = {
       ...defaultOptions,
       ...options
@@ -83,6 +84,7 @@ export class Visit {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
+    this.initiator = initiator
   }
 
   get adapter() {
@@ -158,7 +160,7 @@ export class Visit {
     if (this.hasPreloadedResponse()) {
       this.simulateRequest()
     } else if (this.shouldIssueRequest() && !this.request) {
-      this.request = new FetchRequest(this, FetchMethod.get, this.location)
+      this.request = new FetchRequest(this, FetchMethod.get, this.location, undefined, this.initiator)
       this.request.perform()
     }
   }

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -72,7 +72,7 @@ export class Visit {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
-      direction
+      direction,
       initiator
     } = {
       ...defaultOptions,

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -180,7 +180,7 @@ export class Session {
 
   visitProposedToLocation(location, options) {
     extendURLWithDeprecatedProperties(location)
-    this.adapter.visitProposedToLocation(location, this.sanitizeVisitOptionsForTransfer(options))
+    this.adapter.visitProposedToLocation(location, options)
   }
 
   // Visit delegate
@@ -402,11 +402,6 @@ export class Session {
         return false
       }
     }
-  }
-
-  sanitizeVisitOptionsForTransfer(options) {
-    const { initiator, referrer, visitCachedSnapshot, ...rest } = options
-    return rest
   }
 
   // Private

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -177,7 +177,7 @@ export class Session {
 
   visitProposedToLocation(location, options) {
     extendURLWithDeprecatedProperties(location)
-    this.adapter.visitProposedToLocation(location, options)
+    this.adapter.visitProposedToLocation(location, this.sanitizeVisitOptionsForTransfer(options))
   }
 
   // Visit delegate
@@ -395,6 +395,18 @@ export class Session {
         return false
       }
     }
+  }
+
+  sanitizeVisitOptionsForTransfer(options) {
+    const sanitized = {}
+    Object.entries(options).forEach(([key, value]) => {
+      try {
+        sanitized[key] = structuredClone(value)
+      } catch (_) {
+        // Ignore non-transferable values
+      }
+    })
+    return sanitized
   }
 
   // Private

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -398,15 +398,8 @@ export class Session {
   }
 
   sanitizeVisitOptionsForTransfer(options) {
-    const sanitized = {}
-    Object.entries(options).forEach(([key, value]) => {
-      try {
-        sanitized[key] = structuredClone(value)
-      } catch (_) {
-        // Ignore non-transferable values
-      }
-    })
-    return sanitized
+    const { referrer, visitCachedSnapshot, ...rest } = options
+    return rest
   }
 
   // Private

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -319,7 +319,7 @@ export class Session {
   }
 
   notifyApplicationAfterVisitingLocation(location, action, direction, target) {
-    return dispatch("turbo:visit", { detail: { url: location.href, action, direction, target } })
+    return dispatch("turbo:visit", { target, detail: { url: location.href, action, direction } })
   }
 
   notifyApplicationBeforeCachingSnapshot() {

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -505,8 +505,8 @@ test("test navigating a frame targeting _top from an outer link fires events", a
   await page.click("#outside-navigate-top-link")
 
   await nextEventOnTarget(page, "outside-navigate-top-link", "turbo:click")
-  await nextEventOnTarget(page, "html", "turbo:before-fetch-request")
-  await nextEventOnTarget(page, "html", "turbo:before-fetch-response")
+  await nextEventOnTarget(page, "outside-navigate-top-link", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "outside-navigate-top-link", "turbo:before-fetch-response")
   await nextEventOnTarget(page, "html", "turbo:before-render")
   await nextEventOnTarget(page, "html", "turbo:render")
   await nextEventOnTarget(page, "html", "turbo:load")

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -494,14 +494,26 @@ test("test ignores forms with a [target] attribute that target an iframe with [n
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
 })
 
-test("test visit events are dispatched on the initiator", async ({ page }) => {
+test("test visit events are dispatched on links", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
   await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
   await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:visit")
 })
 
-test("test fetch events are dispatched on the initiator", async ({ page }) => {
+test("test visit events are dispatched on forms", async ({ page }) => {
+  await page.click("#same-origin-unannotated-form button")
+  await nextEventOnTarget(page, "same-origin-unannotated-form", "turbo:before-visit")
+  await nextEventOnTarget(page, "same-origin-unannotated-form", "turbo:visit")
+})
+
+test("test fetch events are dispatched on links", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
   await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-request")
   await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-response")
+})
+
+test("test fetch events are dispatched on forms", async ({ page }) => {
+  await page.click("#same-origin-unannotated-form button")
+  await nextEventOnTarget(page, "same-origin-unannotated-form", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "same-origin-unannotated-form", "turbo:before-fetch-response")
 })

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -11,6 +11,7 @@ import {
   nextBody,
   nextEventNamed,
   noNextEventNamed,
+  nextEventOnTarget,
   pathname,
   pathnameForIFrame,
   readEventLogs,
@@ -491,4 +492,16 @@ test("test ignores forms with a [target] attribute that target an iframe with [n
   await noNextEventNamed(page, "turbo:load")
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+})
+
+test("test visit events are dispatched on the initiator", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link")
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:visit")
+})
+
+test("test fetch events are dispatched on the initiator", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link")
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-response")
 })


### PR DESCRIPTION
This pull request aims to provide a safe way to dispatch events on initiating elements, enabling developers to choose how to handle Visits based on the element that triggered them. (See https://github.com/hotwired/turbo/issues/99). Prior to sending `Visit` options to the adapter, non-transferable properties are removed. When creating a `Visit`, the original options are reinstated. Ideally the sanitization process would be handled by the iOS adapter (just before calling `postMessage`), but for backwards compatibility, it needs to done at this level.